### PR TITLE
Feat: bump version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ path = "src/lib.rs"
 
 [dependencies]
 actix =  "0.9.0"
-casbin = { version = "0.6.2", default-features = false }
+casbin = { version = "0.8.1", default-features = false, features = [ "incremental" ] }
 tokio = { version = "0.2.20", default-features = false, optional = true }
 async-std = { version = "1.5.0", default-features = false, optional = true }
 
 [features]
-default = ["runtime-tokio"]
+default = ["runtime-async-std"]
 
 runtime-tokio = ["casbin/runtime-tokio", "tokio/sync"]
 runtime-async-std = ["casbin/runtime-async-std", "async-std/std"]
@@ -27,4 +27,4 @@ runtime-async-std = ["casbin/runtime-async-std", "async-std/std"]
 [dev-dependencies]
 tokio = { version = "0.2.20", features = [ "full" ] }
 async-std = { version = "1.5.0", features = [ "attributes" ] }
-actix-rt = "1.1.0"
+actix-rt = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 actix =  "0.9.0"
-casbin = { version = "0.8.1", default-features = false, features = [ "incremental" ] }
+casbin = { version = "0.8.3", default-features = false, features = [ "incremental" ] }
 tokio = { version = "0.2.20", default-features = false, optional = true }
 async-std = { version = "1.5.0", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-casbin"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Eason Chai <hackerchai.com@gmail.com>","Cheng JIANG <jiang.cheng@vip.163.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 Add it to `Cargo.toml`
 
 ```rust
-casbin = { version = "0.6.2", default-features = false }
 actix-casbin = "0.1.1"
 actix-rt = "1.1.0"
 ```
@@ -22,7 +21,7 @@ actix-rt = "1.1.0"
 
 ```rust
 use actix_casbin::{CasbinActor, CasbinCmd, CasbinResult};
-use casbin::prelude::*;
+use actix_casbin::casbin::prelude::*;
 
 #[actix_rt::main]
 async fn main() -> Result<()> {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Add it to `Cargo.toml`
 
 ```rust
-actix-casbin = "0.1.1"
+actix-casbin = "0.2.0"
 actix-rt = "1.1.0"
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,45 +13,43 @@ Add it to `Cargo.toml`
 
 ```rust
 actix-casbin = "0.2.0"
-actix-rt = "1.1.0"
+actix-rt = "1.1.1"
 ```
 
 
 ## Example
 
 ```rust
+use actix_casbin::casbin::{DefaultModel, FileAdapter, Result};
 use actix_casbin::{CasbinActor, CasbinCmd, CasbinResult};
-use actix_casbin::casbin::prelude::*;
 
 #[actix_rt::main]
 async fn main() -> Result<()> {
-    let m = DefaultModel::from_file("examples/rbac_model.conf")
-        .await
-        .unwrap();
+    let m = DefaultModel::from_file("examples/rbac_model.conf").await?;
+
     let a = FileAdapter::new("examples/rbac_policy.csv");
 
-    let addr = CasbinActor::new(m, a).await.unwrap();
+    let addr = CasbinActor::new(m, a).await?;
 
-    if let CasbinResult::Enforce(test_enforce) = addr
+    let res = addr
         .send(CasbinCmd::Enforce(
             vec!["alice", "data1", "read"]
                 .iter()
-                .map(|s| s.to_string())
+                .map(|s| (*s).to_string())
                 .collect(),
         ))
-        .await
-        .unwrap()
-        .unwrap()
-    {
-        if test_enforce {
-            println!("Enforce Pass");
-        } else {
-            println!("Enforce Fail");
-        }
-        Ok(())
+        .await;
+
+    let test_enforce = match res {
+        Ok(Ok(CasbinResult::Enforce(result))) => result,
+        _ => panic!("Actor Error"),
+    };
+    if test_enforce {
+        println!("Enforce Pass");
     } else {
-        panic!("Actor Error");
+        println!("Enforce Fail");
     }
+    Ok(())
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
+pub use casbin;
+
 mod casbin_actor;
 pub use casbin_actor::{CasbinActor, CasbinCmd, CasbinResult};


### PR DESCRIPTION
1. update casbin & re-export casbin
2. change async-std as default async runtime
