### PR TITLE
fix: CI support multiple rust toolchians

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
           override: true
 

--- a/src/casbin_actor.rs
+++ b/src/casbin_actor.rs
@@ -90,7 +90,7 @@ impl<T: IEnforcer + 'static> CasbinActor<T> {
     }
 
     pub fn get_enforcer(&mut self) -> Option<Arc<RwLock<T>>> {
-        self.enforcer.as_ref().map(|x| Arc::clone(x))
+        self.enforcer.as_ref().map(Arc::clone)
     }
 }
 


### PR DESCRIPTION
Same issue as: https://github.com/casbin-rs/actix-casbin-auth/pull/34

For now, CI only use stable toolchain:
https://github.com/casbin-rs/actix-casbin/blob/c4e91e518e3414ae9c3542f47ba04c358e38e1b1/.github/workflows/ci.yml#L28

I fixed this issues by replacing `toolchain: stable` with `toolchain: ${{ matrix.rust }}`, now it works fine.