### PR TITLE
fix: cargo clippy error (redundant closure)

### DIFF
--- a/src/casbin_actor.rs
+++ b/src/casbin_actor.rs
@@ -90,7 +90,7 @@ impl<T: IEnforcer + 'static> CasbinActor<T> {
     }
 
     pub fn get_enforcer(&mut self) -> Option<Arc<RwLock<T>>> {
-        self.enforcer.as_ref().map(|x| Arc::clone(x))
+        self.enforcer.as_ref().map(Arc::clone)
     }
 }
 


### PR DESCRIPTION
For now, Auto Build CI failes in `Cargo Clippy` step:
https://github.com/greenhandatsjtu/actix-casbin/runs/6285170050?check_suite_focus=true#step:7:159
```bash
error: redundant closure
Error:   --> src/casbin_actor.rs:93:36
   |
93 |         self.enforcer.as_ref().map(|x| Arc::clone(x))
   |                                    ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `Arc::clone`
   |
   = note: `-D clippy::redundant-closure` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
```
I fixed it by replacing `map(|x| Arc::clone(x))` with `map(Arc::clone)`, which passes clippy now:
![image](https://user-images.githubusercontent.com/40566803/166637746-82db2408-a8d7-4143-bb45-024acac2091b.png)

