### PR TITLE
fix: Initial upgrade to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 actix =  "0.13.0"
 casbin = { version = "2.0.9", default-features = false, features = [ "incremental", "cached"] }
 actix-casbin-auth = { version = "0.4.4", default-features = false }
-tokio = { version = "1.18.1", default-features = false, optional = true }
+tokio = { version = "0.2.22", default-features = false, optional = true }
 async-std = { version = "1.11.0", default-features = false, optional = true }
 futures = "0.3.21"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ name = "actix_casbin"
 path = "src/lib.rs"
 
 [dependencies]
-actix =  "0.10.0"
-casbin = { version = "2.0.1", default-features = false, features = [ "incremental", "cached"] }
-actix-casbin-auth = { version = "0.4.3", default-features = false }
-tokio = { version = "0.2.22", default-features = false, optional = true }
-async-std = { version = "1.6.3", default-features = false, optional = true }
-futures = "0.3"
+actix =  "0.13.0"
+casbin = { version = "2.0.9", default-features = false, features = [ "incremental", "cached"] }
+actix-casbin-auth = { version = "0.4.4", default-features = false }
+tokio = { version = "1.18.1", default-features = false, optional = true }
+async-std = { version = "1.11.0", default-features = false, optional = true }
+futures = "0.3.21"
 
 [features]
 default = ["runtime-async-std"]
@@ -27,6 +27,6 @@ runtime-tokio = ["casbin/runtime-tokio", "tokio/sync", "actix-casbin-auth/runtim
 runtime-async-std = ["casbin/runtime-async-std", "async-std/std", "actix-casbin-auth/runtime-async-std"]
 
 [dev-dependencies]
-tokio = { version = "0.2.22", features = [ "full" ] }
-async-std = { version = "1.6.3", features = [ "attributes" ] }
-actix-rt = "1.1.1"
+tokio = { version = "1.18.1", features = [ "full" ] }
+async-std = { version = "1.11.0", features = [ "attributes" ] }
+actix-rt = "2.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "actix-casbin"
 version = "0.4.2"
 authors = ["Eason Chai <hackerchai.com@gmail.com>","Cheng JIANG <jiang.cheng@vip.163.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "An Actix actor for casbin"
 homepage="https://github.com/casbin-rs/actix-casbin"


### PR DESCRIPTION
Steps followed to migrate from rust 2018 to 2021:

1. `cargo update`
2. `cargo fix –-edition`
3. updated the `cargo.toml --edition`
4. ran `cargo build` to check whether changes are implemented and code is running. 
5. Updated the `Cargo.toml` file dependencies to their latest version
6.` cargo +nightly udeps` to check the unused dependencies, found none
7. `cargo update`
8. `cargo build` to verify the changes are implemented successfully
